### PR TITLE
Add an option to define the name that will be used to create the link

### DIFF
--- a/wpv.sh
+++ b/wpv.sh
@@ -9,15 +9,16 @@
 function print_help {
     echo "\
 Usage:
-    wpv -c [-s <sourcedir>] [-d <sitedir>]
+    wpv -c [-p <sitename>] [-s <sourcedir>] [-d <sitedir>]
     wpv -h
 
-    -c             Create site.
-    -s <sourcedir> Source/project directory. Defaults to current directory.
-    -d <sitedir>   Destination directory relative to <sourcedir>. This is where the WP install will live. Defaults to ''.
-    -n             Run non-interactive. Do not ask questions.
+    -c                Create site.
+    -p <projectname>  Use <projectname> as the name of the site.
+    -s <sourcedir>    Source/project directory. Defaults to current directory.
+    -d <sitedir>      Destination directory relative to <sourcedir>. This is where the WP install will live. Defaults to ''.
+    -n                Run non-interactive. Do not ask questions.
 
-    -h             Display help.
+    -h                Display help.
 
     Usage examples:
         wpv -d www    Sets up WP inside the "www" directory in the current folder. Asks for confirmation.
@@ -52,8 +53,9 @@ function trailingslashit {
 SRC_DIR=$(pwd)
 DEST_DIR=""
 
-while getopts ":cs:d:hn" argname; do
+while getopts "cp:s:d:hn" argname; do
     case $argname in
+        p) SITE_NAME="$OPTARG";;
         s) SRC_DIR="$OPTARG";;
         d) DEST_DIR="$OPTARG";;
         n) DONT_ASK=1;;
@@ -73,7 +75,10 @@ if [ ! -d "$SRC_DIR" ]; then
 fi
 
 # Figure out domain/db name
-SITE_NAME=`basename "$SRC_DIR"`
+if [ "$SITE_NAME" = "" ]; then
+    SITE_NAME=`basename "$SRC_DIR"`
+fi
+
 SITE_NAME=${SITE_NAME// /_}
 SITE_NAME=${SITE_NAME//[^a-zA-Z0-9_-]/}
 SITE_NAME=$(echo "$SITE_NAME" | tr A-Z a-z)

--- a/wpv.sh
+++ b/wpv.sh
@@ -80,10 +80,10 @@ if [ "$SITE_NAME" = "" ]; then
 fi
 
 SITE_NAME=${SITE_NAME// /_}
-SITE_NAME=${SITE_NAME//[^a-zA-Z0-9_-]/}
+SITE_NAME=${SITE_NAME//[^a-zA-Z0-9_.-]/}
 SITE_NAME=$(echo "$SITE_NAME" | tr A-Z a-z)
 DOMAIN_NAME="$SITE_NAME.$(valet domain)"
-DB_NAME="$SITE_NAME"
+DB_NAME=${SITE_NAME//[.-]/_}
 
 # Make sure dest dir does not exist or is empty.
 DEST_DIR=$(untrailingslashit "$SRC_DIR/$DEST_DIR" )
@@ -111,7 +111,7 @@ fi
 
 # Everything checks out, last confirmation (maybe).
 if [ -z "$DONT_ASK" ]; then
-    echo "=> We're about to install a WordPress development environment in \"$DEST_DIR\" with domain name \"$DOMAIN_NAME\" and MySQL database \"$SITE_NAME\"."
+    echo "=> We're about to install a WordPress development environment in \"$DEST_DIR\" with domain name \"$DOMAIN_NAME\" and MySQL database \"$DB_NAME\"."
     read -p "=> Are we gonna do this?... (y/n) " -n 1 -r
     echo
 

--- a/wpv.sh
+++ b/wpv.sh
@@ -53,7 +53,7 @@ function trailingslashit {
 SRC_DIR=$(pwd)
 DEST_DIR=""
 
-while getopts "cp:s:d:hn" argname; do
+while getopts ":cp:s:d:hn" argname; do
     case $argname in
         p) SITE_NAME="$OPTARG";;
         s) SRC_DIR="$OPTARG";;

--- a/wpv.sh
+++ b/wpv.sh
@@ -9,13 +9,12 @@
 function print_help {
     echo "\
 Usage:
-    wpv -c [-p <sitename>] [-s <sourcedir>] [-d <sitedir>]
+    wpv -c [-s <sitename>] [-d <sitedir>]
     wpv -h
 
     -c                Create site.
-    -p <projectname>  Use <projectname> as the name of the site.
-    -s <sourcedir>    Source/project directory. Defaults to current directory.
-    -d <sitedir>      Destination directory relative to <sourcedir>. This is where the WP install will live. Defaults to ''.
+    -s <sitename>     Use <sitename> as the name of the site.
+    -d <sitedir>      Destination directory relative to current directory. This is where the WP install will live. Defaults to ''.
     -n                Run non-interactive. Do not ask questions.
 
     -h                Display help.
@@ -53,10 +52,9 @@ function trailingslashit {
 SRC_DIR=$(pwd)
 DEST_DIR=""
 
-while getopts ":cp:s:d:hn" argname; do
+while getopts ":cs:d:hn" argname; do
     case $argname in
-        p) SITE_NAME="$OPTARG";;
-        s) SRC_DIR="$OPTARG";;
+        s) SITE_NAME="$OPTARG";;
         d) DEST_DIR="$OPTARG";;
         n) DONT_ASK=1;;
         c) DO_SOMETHING=1;;
@@ -66,12 +64,6 @@ done
 
 if [ -z "$DO_SOMETHING" ]; then
     print_help
-fi
-
-# Check source dir is valid.
-SRC_DIR=$(untrailingslashit "$SRC_DIR")
-if [ ! -d "$SRC_DIR" ]; then
-    err "\"$SRC_DIR\" is not a valid directory."
 fi
 
 # Figure out domain/db name


### PR DESCRIPTION
I had modified the previous version of the script so that `vp create public_html next.plugin` would:

* Install WordPress on the `public_html` directory inside the current directory and
* Create a Valet link for the `next.plugin.test` domain pointing to that `public_html` directory.

I added the `-p <projectname>` option to achieve the same goal using `wpv -c -p next.awpcp -d public_html`.

I also modified the script to allow dots (`.`) on project names and replace both `.` and `-` with `_` on database names. Previously trying to use the script inside a directory with `-` on the name, such as `test-plugin`, would try to create a `test-plugin` database and fail.

If being able to configure the project name sounds like something we want, we could avoid adding a new option by making the `-s` option accept the project name (or site name) and always assume that the current directory is the source/project directory.