### PR TITLE
Allow wp core download in a subdir of an existing website

### DIFF
--- a/wpv.sh
+++ b/wpv.sh
@@ -122,7 +122,7 @@ cd "$DEST_DIR"
 mysql -uroot -e "CREATE DATABASE ${DB_NAME}"
 
 # WP core config.
-wp core download
+wp core download --path="$DEST_DIR"
 wp core config --dbname=$DB_NAME --dbuser=root --dbpass='' --extra-php <<-PHP
     define( 'WP_DEBUG', true );
 


### PR DESCRIPTION
Without `--path` WP-CLI exits with an error indicating that "WordPress files seem to already be present here".